### PR TITLE
Fix building with ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ set(CPPCHECK_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cppcheck.out)
 #add_custom_command(OUTPUT ${CPPCHECK_OUTPUT} dummy_file
 #  COMMAND cppcheck -I${CMAKE_CURRENT_SOURCE_DIR}/src --force --enable=all --inconclusive --std=c++14 --library=qt --inline-suppr --quiet --suppress=missingInclude --suppress=missingIncludeSystem ${CMAKE_CURRENT_SOURCE_DIR}/src >& ${CPPCHECK_OUTPUT})
 add_custom_command(OUTPUT ${CPPCHECK_OUTPUT} dummy_file
-  COMMAND $(CMAKE_SOURCE_DIR)/scripts/cppcheck-rg $(CMAKE_SOURCE_DIR)/src >& ${CPPCHECK_OUTPUT})
+  COMMAND ${CMAKE_SOURCE_DIR}/scripts/cppcheck-rg ${CMAKE_SOURCE_DIR}/src >& ${CPPCHECK_OUTPUT})
 
 add_custom_target(cppcheck DEPENDS ${CPPCHECK_OUTPUT} dummy_file)
 #########################


### PR DESCRIPTION
ninja: error: build.ninja:138: bad $-escape (literal $ must be written as $$)
  COMMAND = cd /d/kde/build/6/rosegarden && $(CMAKE_SOURCE_DIR)/scripts/...
                                            ^ near here