### PR TITLE
Add a set of basic CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,41 @@
+{
+    "version": 2,
+    "configurePresets": [
+        {
+            "name": "dev",
+            "description": "Simple development preset",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build-${presetName}",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "USE_QT6": "ON"
+            }
+        },
+        {
+            "name": "dev-clang",
+            "inherits": "dev",
+            "description": "Development preset using Clang",
+            "environment": {
+                "CC": "clang",
+                "CXX": "clang++"
+            }
+        },
+        {
+            "name": "dev-asan",
+            "inherits": "dev",
+            "description": "Simple development preset with sanitizers",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined"
+            }
+        },
+        {
+            "name": "dev-profiling",
+            "inherits": "dev",
+            "description": "Simple development preset with optimizations and debug symbols",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
In case anyone's wondering how to build with ASAN enabled, which makes it much easier to debug crashes such as "use of deleted memory"... all you have to do is
`cmake . --preset dev-asan`

* dev for normal debug build
* dev-clang if you want to use clang (e.g. to get different compiler warnings)
* dev-asan for ASAN (and UBSAN)
* dev-profiling for profiling (performance issues)

CMake Presets also make using vscode much easier.