### PR TITLE
Fix beaming a selection that contains a tuplet losing the tuplet

### DIFF
--- a/src/commands/notation/BeamCommand.cpp
+++ b/src/commands/notation/BeamCommand.cpp
@@ -38,16 +38,42 @@ BeamCommand::registerCommand(CommandRegistry *r)
 void
 BeamCommand::modifySegment()
 {
-    int id = getSegment().getNextId();
+    // If the selection contains notes from a tupled group, we want to
+    // preserve the tuplet.  Find the tupled group ID if any, and use
+    // it as the shared group ID so that non-tupled notes join the same
+    // group rather than a new one that would overwrite the tuplet type.
+    int id = -1;
+    for (EventContainer::iterator i =
+                m_selection->getSegmentEvents().begin();
+            i != m_selection->getSegmentEvents().end(); ++i) {
+        std::string t;
+        if ((*i)->get<String>(BaseProperties::BEAMED_GROUP_TYPE, t)  &&
+            t == BaseProperties::GROUP_TYPE_TUPLED) {
+            long tupledId = -1;
+            (*i)->get<Int>(BaseProperties::BEAMED_GROUP_ID, tupledId);
+            id = static_cast<int>(tupledId);
+            break;
+        }
+    }
+    if (id < 0)
+        id = getSegment().getNextId();
 
     for (EventContainer::iterator i =
                 m_selection->getSegmentEvents().begin();
             i != m_selection->getSegmentEvents().end(); ++i) {
 
         if ((*i)->isa(Note::EventType)) {
-            (*i)->set<Int>(BaseProperties::BEAMED_GROUP_ID, id);
-            (*i)->set<String>(BaseProperties::BEAMED_GROUP_TYPE,
-                              BaseProperties::GROUP_TYPE_BEAMED);
+            std::string t;
+            if ((*i)->get<String>(BaseProperties::BEAMED_GROUP_TYPE, t)  &&
+                t == BaseProperties::GROUP_TYPE_TUPLED) {
+                // Preserve the tuplet group: reassign to the shared ID
+                // but keep GROUP_TYPE_TUPLED so the bracket still renders.
+                (*i)->set<Int>(BaseProperties::BEAMED_GROUP_ID, id);
+            } else {
+                (*i)->set<Int>(BaseProperties::BEAMED_GROUP_ID, id);
+                (*i)->set<String>(BaseProperties::BEAMED_GROUP_TYPE,
+                                  BaseProperties::GROUP_TYPE_BEAMED);
+            }
         }
     }
 }

--- a/src/document/io/LilyPondExporter.cpp
+++ b/src/document/io/LilyPondExporter.cpp
@@ -228,6 +228,17 @@ Event *LilyPondExporter::nextNoteInGroup(const Segment *s,
             return nullptr;
         }
 
+        // For tupled groups, the next note must also be tupled (a note with
+        // the same group ID but a different type, e.g. GROUP_TYPE_BEAMED,
+        // is a beam extension that does not belong to the tuplet bracket).
+        if (tuplet) {
+            std::string nextGroupType;
+            if (!event->get<String>(BEAMED_GROUP_TYPE, nextGroupType) ||
+                nextGroupType != GROUP_TYPE_TUPLED) {
+                return nullptr;
+            }
+        }
+
         // Part of the group.
         return event;
     }

--- a/src/gui/editors/notation/NotationGroup.cpp
+++ b/src/gui/editors/notation/NotationGroup.cpp
@@ -134,7 +134,8 @@ NotationGroup::sample(const NELIterator &i, bool goingForwards)
     }
 
     if (t == BaseProperties::GROUP_TYPE_BEAMED) {
-        m_type = Beamed;
+        if (m_type != Tupled)  // don't downgrade a tupled group
+            m_type = Beamed;
     } else if (t == BaseProperties::GROUP_TYPE_TUPLED) {
         m_type = Tupled;
     } else if (t == BaseProperties::GROUP_TYPE_GRACE) {


### PR DESCRIPTION
BeamCommand::modifySegment() was unconditionally stamping BEAMED_GROUP_TYPE="beamed" on every selected note, overwriting "tupled" on triplet notes and destroying the tuplet bracket.

Fix BeamCommand to reuse the existing tupled group's ID as the shared beam group ID, preserving GROUP_TYPE_TUPLED on the tuplet notes while assigning GROUP_TYPE_BEAMED only to the non-tuplet notes.

Fix NotationGroup::sample() to not downgrade m_type from Tupled to Beamed when a "beamed" note is sampled into the same mixed group.

Fix LilyPondExporter::nextNoteInGroup() to check that the candidate next note's BEAMED_GROUP_TYPE actually matches the requested group type when searching for the next tupled note.  Without this, a "beamed" extension note with the same group ID was returned as the "next tupled note", preventing the closing \times 2/3 } from ever being written.

Bug #1773

Disclaimer: this fix is tested and works for my use case, but it was vibe-coded (using Claude Sonnet). Please review carefully. I didn't take the time to understand all the details of the code.