### PR TITLE
Fix grace note stems lost in LilyPond export

### DIFF
--- a/src/document/io/LilyPondExporter.cpp
+++ b/src/document/io/LilyPondExporter.cpp
@@ -2687,8 +2687,7 @@ LilyPondExporter::writeBar(Segment *s,
                 str << "\\unHideNotes ";
             }
 
-            if (m_exportBeams && startingBeamedGroup && nextBeamedNoteInGroup && canStartOrEndBeam(event)) {
-                // starting a beamed group
+            if (m_exportBeams && startingBeamedGroup && nextBeamedNoteInGroup && canStartOrEndBeam(event) && isGrace == 0) {
                 str << "[ ";
                 startingBeamedGroup = false;
                 inBeamedGroup = true;

--- a/test/lilypond/baseline/lilypond-tied-grace-notes.ly
+++ b/test/lilypond/baseline/lilypond-tied-grace-notes.ly
@@ -39,8 +39,8 @@ globalTempo = {
                 
                 \clef "treble"
                 \key c \major
-                a' 4 \grace { e' 16 } f' 4 \grace { f' 8 [ fis' ] } g' 2  |
-                \grace { \times 2/3 { \stemUp b'' 16 [ a'' g'' ] } } \stemNeutral e'' 4 r \stemUp < c'' e'' > 8 [ \grace { < bes' d'' > } < b' d'' > ] r4 \stemNeutral  |
+                a' 4 \grace { e' 16 } f' 4 \grace { f' 8 fis' } g' 2  |
+                \grace { \times 2/3 { \stemUp b'' 16 a'' g'' } } \stemNeutral e'' 4 r \stemUp < c'' e'' > 8 [ \grace { < bes' d'' > } < b' d'' > ] r4 \stemNeutral  |
                 \stemUp f'' 4 \grace { < des'' f'' > 8 } < d'' f'' > 4 \grace { \stemNeutral e' 16 } f' 4 r 
                 \bar "|."
             } % Voice


### PR DESCRIPTION
When a grace note started a beam group, the beam-start marker `[` was written inside the \grace {} block. LilyPond cannot beam grace notes with regular notes, causing "cyclic dependency" errors and missing stems.

Defer the `[` to the next non-grace note by keeping startingBeamedGroup true when inside a grace context.