### PR TITLE
Fix spurious -Wstringop-overflow warning in ColourMap constructor

### DIFF
--- a/src/base/ColourMap.cpp
+++ b/src/base/ColourMap.cpp
@@ -34,7 +34,7 @@ ColourMap::ColourMap()
     //     RoseXmlHandler, so it's not needed.  Might be worth doing
     //     some comprehensive testing to see if removing this would
     //     make any difference.
-    colours[0] = Entry();
+    colours.emplace(0, Entry());
 }
 
 QColor


### PR DESCRIPTION
GCC gets confused by the move-assignment into the map entry's std::string member. Use emplace() to construct in-place instead.